### PR TITLE
Fix Ensemble dynamics broadcasting

### DIFF
--- a/algorithms/dynamics.py
+++ b/algorithms/dynamics.py
@@ -133,6 +133,7 @@ class EnsembleDynamics:
     ):
         self.dynamics_model = dynamics_model
         self.num_ensemble = len(elite_idxs)
+        self.dynamics_model.num_ensemble = self.num_ensemble
         self.termination_fn = termination_fn
         self.discrepancy = discrepancy
         self.min_r = min_r


### PR DESCRIPTION
## Problem
In `dynamics.py:512`, there's a parameter count mismatch between the `dynamics_net` (initialized with e.g. `num_ensemble=5`) and the elite parameters (filtered to e.g. `num_elite = 3`):

```python
dynamics_model = EnsembleDynamics(
    dynamics_net, train_state.params, elite_idxs, termination_fn, discrepancy, min_r
)
```

This causes shape errors during model application when JAX attempts to perform dot_general operations with mismatched batch dimensions:
```
TypeError: dot_general requires lhs batch dimensions and rhs batch dimensions to have the same shape, got (5,) and (3,).
```

## Root Cause
The issue occurs because:
1. `dynamics_net` is initialized with `num_ensemble=5` networks
2. `self.params` is filtered to only include elite models (`num_elite=3`)
3. When applying the model, the batch dimensions mismatch (5 vs 3)

## Solution
Update the `dynamics_model.num_ensemble` attribute to match the filtered parameter count in the initialization:

```python
        self.dynamics_model = dynamics_model
        self.num_ensemble = len(elite_idxs)
        self.dynamics_model.num_ensemble = self.num_ensemble # update ensemble size
        self.termination_fn = termination_fn
        self.discrepancy = discrepancy
        self.min_r = min_r
        self.dataset = None
```

This ensures the model's expected ensemble size matches the actual parameter count.