### PR TITLE
Fix: CQL ood regularization

### DIFF
--- a/algorithms/cql.py
+++ b/algorithms/cql.py
@@ -303,7 +303,8 @@ def make_train_step(args, actor_apply_fn, q_apply_fn, alpha_apply_fn, dataset):
             q_ood = q_ood * args.cql_temperature
             q_diff = (jnp.expand_dims(q_ood, 1) - q_pred).mean()
             min_q_loss = q_diff * args.cql_min_q_weight
-            critic_loss += min_q_loss
+
+            critic_loss += min_q_loss.mean()
             return critic_loss
 
         critic_loss, critic_grad = _q_loss_fn(agent_state.vec_q.params)


### PR DESCRIPTION
I'm pretty sure the CQL ood loss is not implemented correctly.

a) The softmax is not backpropagated through, so no penalty to OOD actions is actually applied
~~b) The softmax reduces over the ensemble dimension, rather than over the batch~~

Additionally, I'm not entirely sure if next_pi_q should really be evaluated in the next observations. While it technically makes more sense, CORL evaluates the actions in batch.obs, and they seemed to have been able to replicate the CQL performance (albeit with some difficulty - https://github.com/tinkoff-ai/CORL/issues/14).

I think taking the next_actions for estimating the logsumexp for (s,a) is just something that helped during training, its a little odd sure, but i think we should keep the batch.obs there.

To illustrate, here's a simple 1D bandit benchmark with the estimated q-values before/after the fixes.

<img width="640" height="480" alt="CQL broken_q_vals" src="https://github.com/user-attachments/assets/2a687e42-983d-4688-bad2-6fe3b171e8ca" />
<img width="640" height="480" alt="CQL with 0 1 weight_q_vals" src="https://github.com/user-attachments/assets/0cfd9da2-22ca-433c-9d93-99d8a8536a78" />

Thank you for the great library!
